### PR TITLE
Add rerun button on timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ Configure the inputs to customize the Telegram message:
 - `APPROVED_TEXT`: Message to indicate successful approval.
 - `REJECTED_TEXT`: Message to indicate successful rejection.
 - `TIMEOUT_TEXT`: Message to indicate a timeout if no response is received.
-- `ALLOW_RETRY_ON_TIMEOUT`: If `true`, the action will edit the timed-out message to include a retry button that resends a new approval request.
-- `RETRY_BUTTON`: Text for the retry button shown when `ALLOW_RETRY_ON_TIMEOUT` is enabled.
+- `ALLOW_GITHUB_RERUN_ON_TIMEOUT`: If `true`, the action will edit the timed-out message to include a GitHub workflow rerun button. Defaults to `true`.
+- `RERUN_BUTTON`: Text for the rerun button shown when `ALLOW_GITHUB_RERUN_ON_TIMEOUT` is enabled.
+- `RERUN_TEXT`: Message shown after a rerun request is sent to GitHub.
+- `RERUN_FAILED_TEXT`: Message shown if the rerun request fails.
+- `GITHUB_TOKEN`: GitHub token used to rerun workflows (defaults to the workflow `github.token` if available).
 - `UPDATE_REQUESTS`: The number of update requests the action will make to check for manual approval or rejection via Telegram. This is not a strict timeout but rather a count of checks, with each request occurring approximately every 1 to 2 seconds.
 
 You can also set a timeout limit for the approval step using `timeout-minutes` in your workflow file:
@@ -55,11 +58,17 @@ The `timeout-minutes` parameter in your workflow determines the maximum duration
 
 Additionally, the `UPDATE_REQUESTS` input is not a direct timeout setting but rather represents the limit of update checks the action will perform. It is set to a default of 60, which typically corresponds to a duration of 60 to 120 seconds depending on network conditions and server response times, as each update request is expected to occur roughly every 1 to 2 seconds. Adjust the `UPDATE_REQUESTS` value according to how long you want the action to wait for a response in Telegram before considering it a timeout situation and sending the `TIMEOUT_TEXT` message.
 
-If `ALLOW_RETRY_ON_TIMEOUT` is enabled, the action will continue running after the first timeout and wait for a retry click (up to another `UPDATE_REQUESTS` checks). Clicking retry sends a fresh approval request so you can approve without re-running the workflow from GitHub.
+If `ALLOW_GITHUB_RERUN_ON_TIMEOUT` is enabled, the action will show a rerun button and will call the GitHub API to rerun the current workflow run. This requires a token with `actions: write` permission (the default `github.token` works if you set permissions).
+
+Example permissions:
+```yaml
+permissions:
+  actions: write
+```
 
 ### Permissions
 
-Ensure that the GitHub token used by the action has permissions to send messages via Telegram Bot API. You may not need to set any special permissions in your GitHub workflow for this action unless your workflow requires additional steps that interact with the GitHub environment.
+No special GitHub permissions are required for Telegram messaging. If you enable GitHub rerun on timeout, grant `actions: write` to the workflow token.
 
 ### Quick example
 ```yaml

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Configure the inputs to customize the Telegram message:
 - `APPROVED_TEXT`: Message to indicate successful approval.
 - `REJECTED_TEXT`: Message to indicate successful rejection.
 - `TIMEOUT_TEXT`: Message to indicate a timeout if no response is received.
+- `ALLOW_RETRY_ON_TIMEOUT`: If `true`, the action will edit the timed-out message to include a retry button that resends a new approval request.
+- `RETRY_BUTTON`: Text for the retry button shown when `ALLOW_RETRY_ON_TIMEOUT` is enabled.
 - `UPDATE_REQUESTS`: The number of update requests the action will make to check for manual approval or rejection via Telegram. This is not a strict timeout but rather a count of checks, with each request occurring approximately every 1 to 2 seconds.
 
 You can also set a timeout limit for the approval step using `timeout-minutes` in your workflow file:
@@ -52,6 +54,8 @@ Please note that the `TIMEOUT_TEXT` message is specifically related to the `UPDA
 The `timeout-minutes` parameter in your workflow determines the maximum duration that the action will wait for an approval response before the step times out. If this workflow step timeout is reached without an approval or rejection, the action will simply cease to operate and will not send the `TIMEOUT_TEXT` message.
 
 Additionally, the `UPDATE_REQUESTS` input is not a direct timeout setting but rather represents the limit of update checks the action will perform. It is set to a default of 60, which typically corresponds to a duration of 60 to 120 seconds depending on network conditions and server response times, as each update request is expected to occur roughly every 1 to 2 seconds. Adjust the `UPDATE_REQUESTS` value according to how long you want the action to wait for a response in Telegram before considering it a timeout situation and sending the `TIMEOUT_TEXT` message.
+
+If `ALLOW_RETRY_ON_TIMEOUT` is enabled, the action will continue running after the first timeout and wait for a retry click (up to another `UPDATE_REQUESTS` checks). Clicking retry sends a fresh approval request so you can approve without re-running the workflow from GitHub.
 
 ### Permissions
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The `timeout-minutes` parameter in your workflow determines the maximum duration
 
 Additionally, the `UPDATE_REQUESTS` input is not a direct timeout setting but rather represents the limit of update checks the action will perform. It is set to a default of 60, which typically corresponds to a duration of 60 to 120 seconds depending on network conditions and server response times, as each update request is expected to occur roughly every 1 to 2 seconds. Adjust the `UPDATE_REQUESTS` value according to how long you want the action to wait for a response in Telegram before considering it a timeout situation and sending the `TIMEOUT_TEXT` message.
 
-If `ALLOW_GITHUB_RERUN_ON_TIMEOUT` is enabled, the action will show a rerun button and will attempt a `workflow_dispatch` for the same workflow. It derives the workflow file and ref from the GitHub Actions environment and falls back to the rerun API if dispatch isn't possible. This requires a token with `actions: write` permission (the default `github.token` works if you set permissions).
+If `ALLOW_GITHUB_RERUN_ON_TIMEOUT` is enabled, the action will show a rerun button and will attempt a `workflow_dispatch` for the same workflow. It derives the workflow file and ref from the GitHub Actions environment. This requires a token with `actions: write` permission (the default `github.token` works if you set permissions).
 
 Example permissions:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Configure the inputs to customize the Telegram message:
 - `RERUN_TEXT`: Message shown after a rerun request is sent to GitHub.
 - `RERUN_FAILED_TEXT`: Message shown if the rerun request fails.
 - `GITHUB_TOKEN`: GitHub token used to rerun workflows (defaults to the workflow `github.token` if available).
+- `RERUN_WORKFLOW_FILE`: Workflow file to dispatch on rerun (e.g. `deploy.yml`). Optional override if auto-detection fails.
+- `RERUN_REF`: Ref to use for workflow dispatch (branch or tag). Optional override if auto-detection fails.
 - `UPDATE_REQUESTS`: The number of update requests the action will make to check for manual approval or rejection via Telegram. This is not a strict timeout but rather a count of checks, with each request occurring approximately every 1 to 2 seconds.
 
 You can also set a timeout limit for the approval step using `timeout-minutes` in your workflow file:
@@ -58,13 +60,21 @@ The `timeout-minutes` parameter in your workflow determines the maximum duration
 
 Additionally, the `UPDATE_REQUESTS` input is not a direct timeout setting but rather represents the limit of update checks the action will perform. It is set to a default of 60, which typically corresponds to a duration of 60 to 120 seconds depending on network conditions and server response times, as each update request is expected to occur roughly every 1 to 2 seconds. Adjust the `UPDATE_REQUESTS` value according to how long you want the action to wait for a response in Telegram before considering it a timeout situation and sending the `TIMEOUT_TEXT` message.
 
-If `ALLOW_GITHUB_RERUN_ON_TIMEOUT` is enabled, the action will show a rerun button and will call the GitHub API to rerun the current workflow run. This requires a token with `actions: write` permission (the default `github.token` works if you set permissions).
+If `ALLOW_GITHUB_RERUN_ON_TIMEOUT` is enabled, the action will show a rerun button and will attempt a `workflow_dispatch` for the same workflow. It derives the workflow file and ref from the GitHub Actions environment and falls back to the rerun API if dispatch isn't possible. This requires a token with `actions: write` permission (the default `github.token` works if you set permissions).
 
 Example permissions:
 ```yaml
 permissions:
   actions: write
 ```
+
+If the workflow does not include `workflow_dispatch`, add it:
+```yaml
+on:
+  workflow_dispatch:
+```
+
+If auto-detection fails, set `RERUN_WORKFLOW_FILE` and `RERUN_REF` explicitly.
 
 ### Permissions
 

--- a/action.yml
+++ b/action.yml
@@ -58,10 +58,18 @@ inputs:
     description: 'GitHub token used to rerun workflows'
     required: false
     default: ''
+  RERUN_WORKFLOW_FILE:
+    description: 'Workflow file to dispatch on rerun (e.g. deploy.yml)'
+    required: false
+    default: ''
+  RERUN_REF:
+    description: 'Ref to use for workflow dispatch (branch or tag)'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}" --ALLOW_GITHUB_RERUN_ON_TIMEOUT ${{ inputs.ALLOW_GITHUB_RERUN_ON_TIMEOUT }} --RERUN_BUTTON "${{ inputs.RERUN_BUTTON }}" --RERUN_TEXT "${{ inputs.RERUN_TEXT }}" --RERUN_FAILED_TEXT "${{ inputs.RERUN_FAILED_TEXT }}"
+    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}" --ALLOW_GITHUB_RERUN_ON_TIMEOUT ${{ inputs.ALLOW_GITHUB_RERUN_ON_TIMEOUT }} --RERUN_BUTTON "${{ inputs.RERUN_BUTTON }}" --RERUN_TEXT "${{ inputs.RERUN_TEXT }}" --RERUN_FAILED_TEXT "${{ inputs.RERUN_FAILED_TEXT }}" --RERUN_WORKFLOW_FILE "${{ inputs.RERUN_WORKFLOW_FILE }}" --RERUN_REF "${{ inputs.RERUN_REF }}"
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN || github.token }}

--- a/action.yml
+++ b/action.yml
@@ -38,16 +38,30 @@ inputs:
     description: 'Text of timeout'
     required: false
     default: 'Timeout!'
-  ALLOW_RETRY_ON_TIMEOUT:
-    description: 'Allow a retry button after timeout to resend approval request'
+  ALLOW_GITHUB_RERUN_ON_TIMEOUT:
+    description: 'Allow a GitHub workflow rerun button after timeout'
     required: false
-    default: 'false'
-  RETRY_BUTTON:
-    description: 'Text of retry button'
+    default: 'true'
+  RERUN_BUTTON:
+    description: 'Text of GitHub rerun button'
     required: false
-    default: 'Retry'
+    default: 'Rerun workflow'
+  RERUN_TEXT:
+    description: 'Text shown when rerun is requested'
+    required: false
+    default: 'Rerun requested.'
+  RERUN_FAILED_TEXT:
+    description: 'Text shown when rerun fails'
+    required: false
+    default: 'Rerun failed.'
+  GITHUB_TOKEN:
+    description: 'GitHub token used to rerun workflows'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}" --ALLOW_RETRY_ON_TIMEOUT ${{ inputs.ALLOW_RETRY_ON_TIMEOUT }} --RETRY_BUTTON "${{ inputs.RETRY_BUTTON }}"
+    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}" --ALLOW_GITHUB_RERUN_ON_TIMEOUT ${{ inputs.ALLOW_GITHUB_RERUN_ON_TIMEOUT }} --RERUN_BUTTON "${{ inputs.RERUN_BUTTON }}" --RERUN_TEXT "${{ inputs.RERUN_TEXT }}" --RERUN_FAILED_TEXT "${{ inputs.RERUN_FAILED_TEXT }}" --GITHUB_TOKEN "${{ inputs.GITHUB_TOKEN }}"
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN || github.token }}

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}" --ALLOW_GITHUB_RERUN_ON_TIMEOUT ${{ inputs.ALLOW_GITHUB_RERUN_ON_TIMEOUT }} --RERUN_BUTTON "${{ inputs.RERUN_BUTTON }}" --RERUN_TEXT "${{ inputs.RERUN_TEXT }}" --RERUN_FAILED_TEXT "${{ inputs.RERUN_FAILED_TEXT }}" --GITHUB_TOKEN "${{ inputs.GITHUB_TOKEN }}"
+    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}" --ALLOW_GITHUB_RERUN_ON_TIMEOUT ${{ inputs.ALLOW_GITHUB_RERUN_ON_TIMEOUT }} --RERUN_BUTTON "${{ inputs.RERUN_BUTTON }}" --RERUN_TEXT "${{ inputs.RERUN_TEXT }}" --RERUN_FAILED_TEXT "${{ inputs.RERUN_FAILED_TEXT }}"
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN || github.token }}

--- a/action.yml
+++ b/action.yml
@@ -38,8 +38,16 @@ inputs:
     description: 'Text of timeout'
     required: false
     default: 'Timeout!'
+  ALLOW_RETRY_ON_TIMEOUT:
+    description: 'Allow a retry button after timeout to resend approval request'
+    required: false
+    default: 'false'
+  RETRY_BUTTON:
+    description: 'Text of retry button'
+    required: false
+    default: 'Retry'
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}"
+    - run: $GITHUB_ACTION_PATH/main.sh --TELEGRAM_KEY ${{ inputs.TELEGRAM_KEY }} --TELEGRAM_CHAT_ID ${{ inputs.TELEGRAM_CHAT_ID }} --UPDATE_REQUESTS ${{ inputs.UPDATE_REQUESTS }} --APPROVAL_TEXT "${{ inputs.APPROVAL_TEXT }}" --APPROVAL_BUTTON "${{ inputs.APPROVAL_BUTTON }}" --REJECT_BUTTON "${{ inputs.REJECT_BUTTON }}" --APPROVED_TEXT "${{ inputs.APPROVED_TEXT }}" --REJECTED_TEXT "${{ inputs.REJECTED_TEXT }}" --TIMEOUT_TEXT "${{ inputs.TIMEOUT_TEXT }}" --ALLOW_RETRY_ON_TIMEOUT ${{ inputs.ALLOW_RETRY_ON_TIMEOUT }} --RETRY_BUTTON "${{ inputs.RETRY_BUTTON }}"
       shell: bash

--- a/main.sh
+++ b/main.sh
@@ -161,7 +161,7 @@ getUpdates() {
 }
 
 updateMessage() {
-  local text=$1
+  local text="$1"
 
   curl -s --location --request POST "https://api.telegram.org/bot$TELEGRAM_KEY/editMessageText" \
     --header 'Content-Type: application/json' \
@@ -183,17 +183,17 @@ while true; do
 
   if [ $RESULT -eq 1 ]; then
     echo "Approved"
-    updateMessage $APPROVED_TEXT
+    updateMessage "$APPROVED_TEXT"
     exit 0
   elif [ $RESULT -eq 2 ]; then
     echo "Rejected"
-    updateMessage $REJECTED_TEXT
+    updateMessage "$REJECTED_TEXT"
     exit 1
   fi
 
   if [ $UPDATE_REQUESTS_COUNTER -gt $UPDATE_REQUESTS ]; then
     echo "Update requests limit reached"
-    updateMessage $TIMEOUT_TEXT
+    updateMessage "$TIMEOUT_TEXT"
     exit 1
   fi
   UPDATE_REQUESTS_COUNTER=$((UPDATE_REQUESTS_COUNTER + 1))

--- a/main.sh
+++ b/main.sh
@@ -15,10 +15,9 @@ ALLOW_GITHUB_RERUN_ON_TIMEOUT="true"
 RERUN_BUTTON="Rerun workflow"
 RERUN_TEXT="Rerun requested."
 RERUN_FAILED_TEXT="Rerun failed."
-GH_TOKEN=""
 
 # Define long options
-LONGOPTS=TELEGRAM_KEY:,TELEGRAM_CHAT_ID:,UPDATE_REQUESTS:,APPROVAL_TEXT:,APPROVAL_BUTTON:,REJECT_BUTTON:,APPROVED_TEXT:,REJECTED_TEXT:,TIMEOUT_TEXT:,ALLOW_GITHUB_RERUN_ON_TIMEOUT:,RERUN_BUTTON:,RERUN_TEXT:,RERUN_FAILED_TEXT:,GITHUB_TOKEN:
+LONGOPTS=TELEGRAM_KEY:,TELEGRAM_CHAT_ID:,UPDATE_REQUESTS:,APPROVAL_TEXT:,APPROVAL_BUTTON:,REJECT_BUTTON:,APPROVED_TEXT:,REJECTED_TEXT:,TIMEOUT_TEXT:,ALLOW_GITHUB_RERUN_ON_TIMEOUT:,RERUN_BUTTON:,RERUN_TEXT:,RERUN_FAILED_TEXT:
 
 VALID_ARGS=$(getopt --longoptions $LONGOPTS -- "$@")
 if [[ $? -ne 0 ]]; then
@@ -87,10 +86,6 @@ while true; do
       RERUN_FAILED_TEXT="$2"
       shift 2
       ;;
-    --GITHUB_TOKEN)
-      GH_TOKEN="$2"
-      shift 2
-      ;;
     --)
       shift
       break
@@ -141,9 +136,7 @@ echo "Session ID: $SESSION_ID"
 MESSAGE_ID=""
 
 getGithubToken() {
-  if [ -n "$GH_TOKEN" ]; then
-    echo "$GH_TOKEN"
-  elif [ -n "$GITHUB_TOKEN" ]; then
+  if [ -n "$GITHUB_TOKEN" ]; then
     echo "$GITHUB_TOKEN"
   else
     echo ""

--- a/main.sh
+++ b/main.sh
@@ -15,9 +15,12 @@ ALLOW_GITHUB_RERUN_ON_TIMEOUT="true"
 RERUN_BUTTON="Rerun workflow"
 RERUN_TEXT="Rerun requested."
 RERUN_FAILED_TEXT="Rerun failed."
+RERUN_WORKFLOW_FILE=""
+RERUN_REF=""
+LAST_RERUN_STATUS=""
 
 # Define long options
-LONGOPTS=TELEGRAM_KEY:,TELEGRAM_CHAT_ID:,UPDATE_REQUESTS:,APPROVAL_TEXT:,APPROVAL_BUTTON:,REJECT_BUTTON:,APPROVED_TEXT:,REJECTED_TEXT:,TIMEOUT_TEXT:,ALLOW_GITHUB_RERUN_ON_TIMEOUT:,RERUN_BUTTON:,RERUN_TEXT:,RERUN_FAILED_TEXT:
+LONGOPTS=TELEGRAM_KEY:,TELEGRAM_CHAT_ID:,UPDATE_REQUESTS:,APPROVAL_TEXT:,APPROVAL_BUTTON:,REJECT_BUTTON:,APPROVED_TEXT:,REJECTED_TEXT:,TIMEOUT_TEXT:,ALLOW_GITHUB_RERUN_ON_TIMEOUT:,RERUN_BUTTON:,RERUN_TEXT:,RERUN_FAILED_TEXT:,RERUN_WORKFLOW_FILE:,RERUN_REF:
 
 VALID_ARGS=$(getopt --longoptions $LONGOPTS -- "$@")
 if [[ $? -ne 0 ]]; then
@@ -86,6 +89,14 @@ while true; do
       RERUN_FAILED_TEXT="$2"
       shift 2
       ;;
+    --RERUN_WORKFLOW_FILE)
+      RERUN_WORKFLOW_FILE="$2"
+      shift 2
+      ;;
+    --RERUN_REF)
+      RERUN_REF="$2"
+      shift 2
+      ;;
     --)
       shift
       break
@@ -140,6 +151,71 @@ getGithubToken() {
     echo "$GITHUB_TOKEN"
   else
     echo ""
+  fi
+}
+
+extractWorkflowFromValue() {
+  local value="$1"
+
+  if [[ "$value" == *".github/workflows/"* ]]; then
+    local after="${value#*.github/workflows/}"
+    after="${after%@*}"
+    echo "$after"
+  fi
+}
+
+getDispatchWorkflowFile() {
+  if [ -n "$RERUN_WORKFLOW_FILE" ]; then
+    echo "$RERUN_WORKFLOW_FILE"
+    return
+  fi
+
+  local extracted
+  extracted=$(extractWorkflowFromValue "$GITHUB_WORKFLOW_REF")
+  if [ -n "$extracted" ]; then
+    echo "$extracted"
+    return
+  fi
+
+  extracted=$(extractWorkflowFromValue "$GITHUB_WORKFLOW")
+  if [ -n "$extracted" ]; then
+    echo "$extracted"
+    return
+  fi
+
+  if [ -n "$GITHUB_WORKFLOW" ]; then
+    if [[ "$GITHUB_WORKFLOW" == *.yml ]] || [[ "$GITHUB_WORKFLOW" == *.yaml ]]; then
+      echo "$GITHUB_WORKFLOW"
+      return
+    fi
+  fi
+}
+
+getDispatchRef() {
+  if [ -n "$RERUN_REF" ]; then
+    echo "$RERUN_REF"
+    return
+  fi
+
+  if [ -n "$GITHUB_BASE_REF" ]; then
+    echo "$GITHUB_BASE_REF"
+    return
+  fi
+
+  if [ -n "$GITHUB_REF_NAME" ]; then
+    if [[ "$GITHUB_REF_NAME" != */merge ]]; then
+      echo "$GITHUB_REF_NAME"
+      return
+    fi
+  fi
+
+  if [[ "$GITHUB_REF" == refs/heads/* ]]; then
+    echo "${GITHUB_REF#refs/heads/}"
+    return
+  fi
+  if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+    echo "${GITHUB_REF#refs/tags/}"
+    return
   fi
 }
 
@@ -258,8 +334,17 @@ timeoutWaitLabel() {
   fi
 }
 
+rerunFailedMessage() {
+  if [ -n "$LAST_RERUN_STATUS" ]; then
+    echo "${RERUN_FAILED_TEXT} (status $LAST_RERUN_STATUS)"
+  else
+    echo "$RERUN_FAILED_TEXT"
+  fi
+}
+
 rerunWorkflow() {
   local token="$1"
+  local status
 
   if [ -z "$token" ]; then
     echo "Missing GitHub token for rerun"
@@ -270,7 +355,6 @@ rerunWorkflow() {
     return 3
   fi
 
-  local status
   status=$(curl -s -o /dev/null -w "%{http_code}" \
     --location \
     --request POST \
@@ -279,11 +363,49 @@ rerunWorkflow() {
     --header "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/rerun")
 
+  LAST_RERUN_STATUS="$status"
   if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
     return 0
   fi
 
   echo "Rerun request failed with status $status"
+  return 1
+}
+
+dispatchWorkflow() {
+  local token="$1"
+  local workflow_file="$2"
+  local ref="$3"
+  local status
+
+  if [ -z "$token" ]; then
+    echo "Missing GitHub token for dispatch"
+    return 2
+  fi
+  if [ -z "$GITHUB_REPOSITORY" ]; then
+    echo "Missing GITHUB_REPOSITORY"
+    return 3
+  fi
+  if [ -z "$workflow_file" ] || [ -z "$ref" ]; then
+    echo "Missing workflow file or ref for dispatch"
+    return 4
+  fi
+
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    --location \
+    --request POST \
+    --header "Authorization: Bearer $token" \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_file/dispatches" \
+    --data '{"ref":"'"$ref"'"}')
+
+  LAST_RERUN_STATUS="$status"
+  if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+    return 0
+  fi
+
+  echo "Workflow dispatch failed with status $status"
   return 1
 }
 
@@ -308,11 +430,24 @@ while true; do
   elif [ $RESULT -eq 3 ]; then
     if [ "$STATE" = "timeout" ]; then
       echo "Rerun requested"
+      LAST_RERUN_STATUS=""
       token=$(getGithubToken)
+      workflow_file=$(getDispatchWorkflowFile)
+      ref=$(getDispatchRef)
+      if [ -n "$workflow_file" ] && [ -n "$ref" ]; then
+        echo "Attempting workflow dispatch for $workflow_file@$ref"
+        if dispatchWorkflow "$token" "$workflow_file" "$ref"; then
+          updateMessageClearButtons "$RERUN_TEXT"
+          exit 1
+        fi
+      else
+        echo "Workflow dispatch info missing; falling back to rerun"
+      fi
+
       if rerunWorkflow "$token"; then
         updateMessageClearButtons "$RERUN_TEXT"
       else
-        updateMessageClearButtons "$RERUN_FAILED_TEXT"
+        updateMessageClearButtons "$(rerunFailedMessage)"
       fi
       exit 1
     fi


### PR DESCRIPTION
Adds a rerun button in Telegram when approval times out. The action calls the GitHub API to rerun the current workflow run and updates the message. Documents new inputs and token permission requirement.